### PR TITLE
当日の過去の時間を非表示、予約失敗時の対処

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -138,9 +138,15 @@ class ReservationsController < ApplicationController
 
     # 人数を選択した場合(1日あたりの15:00~23:00の15分単位での予約受入の真偽判定)
     boolean_list = Reservation.reservable_list(date, guest_number)
-    time = Time.new(2000, 1, 1, Reservation::START_TIME, 0, 0)
+    time = Time.new(date.year, date.mon, date.day, Reservation::START_TIME, 0, 0)
     boolean_list.each do |boolean|
-      available_time << time.strftime("%H:%M") if boolean
+      if date == Date.today
+        if boolean && time > Time.current
+          available_time << time.strftime("%H:%M")
+        end
+      else
+        available_time << time.strftime("%H:%M") if boolean
+      end
       time += 15.minute
     end
     available_time

--- a/app/javascript/packs/reservation.js
+++ b/app/javascript/packs/reservation.js
@@ -211,7 +211,7 @@ document.addEventListener('turbolinks:load', () => {
     })
       .then((response) => {
         if (response.ok) {
-          alert('予約に成功しました!');
+          // alert('予約に成功しました!');
           location.href = '/reservations/confirmation';
         } else {
           return response.json();
@@ -219,6 +219,9 @@ document.addEventListener('turbolinks:load', () => {
       })
       .then((data) => {
         alert(data.error);
+        // 戻るボタンをクリックした時と同じ処理
+        disappearModal();
+        changeAvailableDates();
       });
   };
 

--- a/app/models/reservation_status.rb
+++ b/app/models/reservation_status.rb
@@ -2,7 +2,7 @@ class ReservationStatus < ApplicationRecord
   # 基本的なバリデーションは入れる
   # 日付 YYYY-MM-DD
   VALID_DATE_REGEX = /\A\d{4}-\d{2}-\d{2}\z/
-  RESERVATION_OVER_MESSAGE = "予約オーバーです"
+  RESERVATION_OVER_MESSAGE = "申し訳ありません。\n予約人数を越えました。\n再度、予約人数、予約日、予約時間をお選びください。"
 
   validates :minimum_total_num, presence: true, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 12 }
   validates :date, presence: true, uniqueness: true  #, :format {with: VALID_DATE_REGEX}


### PR DESCRIPTION
-当日の過ぎた時間を予約時間選択部分で非表示にする
-予約に失敗した時に、予約ページに戻り、情報を初期状態にする(modalに記入したお客様情報はキープする)
