### PR TITLE
予約編集時に人数変更した際に予約可能日を再計算する

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -203,7 +203,7 @@ class Reservation < ApplicationRecord
     reservable_array
   end
 
-  # 貸切予約が出来るかどうかの真��配列
+  # 貸切予約が出来るかどうかの真偽配列
   def self.choose_private_reservation(date, exclude_reservation_id = nil)
     # reservation_list = reserve_list(date)
     # available_seats_list = biggest_num_list(date)


### PR DESCRIPTION
-管理画面で予約編集時に予約人数を変更した際に、元々の予約を予約解除状態に戻し、予約可能日を再計算する
(reservation_controller_rb)のavailable_dateメソッドを編集
※予約データ(exclude_reservation_id)から予約日を取得してavailable_dates=[]に再投入